### PR TITLE
Speed up build using dockerignore and better ordering

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.deploy
+node_modules
+test
+dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ FROM mhart/alpine-node:10
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app
+EXPOSE 3000
+
+COPY package.json yarn.lock ./
 RUN yarn install
 
-COPY . /usr/src/app
+CMD yarn start:prod
 
-EXPOSE 3000
-CMD yarn run start:prod
+COPY . ./
+RUN yarn build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Einführung Microservice
-REST 
+REST
 
 CRUD
 Create
@@ -7,7 +7,7 @@ Read
 Update
 Delete
 
-POST    /api/waterfill - CREATE 
+POST    /api/waterfill - CREATE
 GET     /api/waterfill?timestamp=1232145 - READ ALL
 GET     /api/waterfill/:id - READ
 PUT     /api/waterfill/:id - UPDATE
@@ -18,24 +18,26 @@ DTO - Data Transfer Object
 ## Meine awesome todo Liste für Microservices:
 1.  VS Code installieren
 2.  NodeJS LTS installieren
-3.  Yarn installieren mit npm i -g yarm
-4.  Typescript installieren npm i -g typescript
-5.  NestCLI installieren npm i -g @nestjs/cli
+3.  Yarn installieren mit `npm i -g yarm`
+4.  Typescript installieren `npm i -g typescript`
+5.  NestCLI installieren `npm i -g @nestjs/cli`
 6.  Mongodb installieren
 7.  Projekt genieren
 8.  Docker installieren
-9.  yarn build
-10. docker build -t kosren/water-fill:latest .
-11. docker login
-12. docker push kosren/water-fill:latest
-13. docker run -it -p 3000:3000 whatever (-e "TOKEN=12334")
+9.  `yarn build`
+10. `docker build -t kosren/water-fill:latest .`
+11. `docker login`
+12. `docker push kosren/water-fill:latest` (hier ist der Tag `kosren/water-fill:latest`)
+13. `docker run -it -p 3000:3000 whatever` (`-e "TOKEN=12334"`)
 
 ## Deploy
-1. Prüft ob ihr die gleichen Dependencies wie im Demo Service habt
-2. Schickt den Tag eures Docker Images und die benötigen Umgebungsvariablen an Seb
-3. Wartet auf Antwort von Seb
-4. Ändert die makierten Stellen im Deploy Skript
-5. Benutzt das deploy Skript zum updaten eures Service yarn run cross-env RANCHER_ACCESS=<TOKEN> RANCHER_KEY=<TOKEN> node .deploy
+1. Prüft, ob ihr die gleichen Dependencys wie im Demo Service habt.
+2. Schickt den Tag Eures Docker Images und die benötigen Umgebungsvariablen an Seb.
+3. Wartet auf Antwort von Seb.
+4. Ändert die makierten Stellen im Deploy-Skript.
+5. Benutzt das Deploy-Skript zum Updaten eures Service `yarn run cross-env RANCHER_ACCESS=<TOKEN> RANCHER_KEY=<TOKEN> node .deploy`
 
 ## Verfügbare Dienste
-Waterfill   -   http://avocado.uniks.de:13345/api
+| Name      | URL                                 |
+|-----------|-------------------------------------|
+| Waterfill | http://avocado.uniks.de:13345/api   |


### PR DESCRIPTION
- `EXPOSE` und `CMD` nach oben geschoben, damit weniger Layer entstehen
- `.dockerignore` hinzugefügt, damit weniger kopiert wird
- `yarn.lock` für reproduzierbare Builds in den Container gepackt
- Anwendung wird beim Container-Bau kompiliert.